### PR TITLE
slash before images does not work locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </div>
     
     <div  class="index-title clearfix">
-        <img class="idx-title-img" src="/images/Scalloped_hammerhead_at_Burgers'_Zoo.jpg" alt="Hammerhead">
+        <img class="idx-title-img" src="images/Scalloped_hammerhead_at_Burgers'_Zoo.jpg" alt="Hammerhead">
         <h1 class="idx-title-overlap">Haie</h1>
     </div>
     


### PR DESCRIPTION
This only works online, because the images-folder is in the root-directory.
For local development, the slash leads to the image not being found.